### PR TITLE
oraclejdk8 -> openjdk8, because travis doesn't accept the former anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 cache:
   directories:
     - "$HOME/.m2/repository"


### PR DESCRIPTION
@DANS-KNAW/easy for review